### PR TITLE
Declare this.map as an empty array

### DIFF
--- a/src/vivus.js
+++ b/src/vivus.js
@@ -206,7 +206,8 @@ Vivus.prototype.setOptions = function (options) {
   this.forceRender = options.hasOwnProperty('forceRender') ? !!options.forceRender : this.isIE;
   this.selfDestroy = !!options.selfDestroy;
   this.onReady     = options.onReady;
-  this.frameLength = this.currentFrame = this.map = this.delayUnit = this.speed = this.handle = null;
+  this.map         = new Array();
+  this.frameLength = this.currentFrame = this.delayUnit = this.speed = this.handle = null;
 
   this.ignoreInvisible = options.hasOwnProperty('ignoreInvisible') ? !!options.ignoreInvisible : false;
 


### PR DESCRIPTION
Declaring `this.map`as an empty array prevents `Cannot read property length of null` error (e.g. from vivus.js:392). Error occurs if all Vivus objects are set to `display: none;`, for example.